### PR TITLE
cfclient connection fix

### DIFF
--- a/components/core/crazyflie/modules/src/system.c
+++ b/components/core/crazyflie/modules/src/system.c
@@ -200,7 +200,7 @@ void systemTask(void *arg)
   //  platformSetLowInterferenceRadioMode();
   //}
   soundInit();
-  //memInit();
+  memInit();
 
 #ifdef PROXIMITY_ENABLED
   proximityInit();


### PR DESCRIPTION
This will fix cfclient connection as it send request to Memory port refresh:
https://github.com/leeebo/crazyflie-lib-python/blob/3c24e993bfa8eb8b3710bd1a3577e647aab6d7e3/cflib/crazyflie/__init__.py#L181C22-L181C22

and awaits response in callback:
https://github.com/leeebo/crazyflie-lib-python/blob/3c24e993bfa8eb8b3710bd1a3577e647aab6d7e3/cflib/crazyflie/__init__.py#L173

which never happened and further handshake sequence was interrupted.

I'm not sure was it task important, but i see heavy data exchange using Port 5 (MEM) between client and firmware during link is active, and I didn't saw yet any issues during my tests