### PR TITLE
Use barometer data for altitude hold

### DIFF
--- a/components/core/crazyflie/hal/src/sensors_mpu6050_hm5883L_ms5611.c
+++ b/components/core/crazyflie/hal/src/sensors_mpu6050_hm5883L_ms5611.c
@@ -305,18 +305,21 @@ void sensorsMpu6050Hmc5883lMs5611WaitDataReady(void)
 
 void processBarometerMeasurements(const uint8_t *buffer)
 {
-    //TODO: replace it to MS5611
-    DEBUG_PRINTW("processBarometerMeasurements NEED TODO");
-//   static uint32_t rawPressure = 0;
-//   static int16_t rawTemp = 0;
+    static uint32_t rawPressure = 0;
+    static int16_t rawTemp = 0;
 
-// Check if there is a new pressure update
+    // Check if there is a new pressure update
+    if (buffer[0] & 0x02) {
+        rawPressure = ((uint32_t) buffer[3] << 16) | ((uint32_t) buffer[2] << 8) | buffer[1];
+    }
+    // Check if there is a new temp update
+    if (buffer[0] & 0x01) {
+        rawTemp = ((int16_t) buffer[5] << 8) | buffer[4];
+    }
 
-// Check if there is a new temp update
-
-//   sensorData.baro.pressure = (float) rawPressure / LPS25H_LSB_PER_MBAR;
-//   sensorData.baro.temperature = LPS25H_TEMP_OFFSET + ((float) rawTemp / LPS25H_LSB_PER_CELSIUS);
-//   sensorData.baro.asl = lps25hPressureToAltitude(&sensorData.baro.pressure);
+    sensorData.baro.pressure = (float) rawPressure / MS5611_LSB_PER_MBAR;
+    sensorData.baro.temperature = MS5611_TEMP_OFFSET + ((float) rawTemp / MS5611_LSB_PER_CELSIUS);
+    sensorData.baro.asl = ms5611PressureToAltitude(&sensorData.baro.pressure);
 }
 
 void processMagnetometerMeasurements(const uint8_t *buffer)


### PR DESCRIPTION
Related to #89

Implement the use of barometer data for altitude/height hold.

* **Process Barometer Measurements**
  - Implement the `processBarometerMeasurements` function in `sensors_mpu6050_hm5883L_ms5611.c` to process barometer data from the MS5611 sensor.
  - Update the `sensorsSetupSlaveRead` function to configure the MS5611 sensor for reading pressure and temperature data.
  - Update the `sensorsTask` function to call `processBarometerMeasurements` when barometer data is available.

* **Altitude Estimation**
  - Update the `positionEstimateInternal` function in `position_estimator_altitude.c` to incorporate barometer data for altitude estimation.
  - Add a blending factor `baroAlpha` for barometer data in the `selfState_s` structure.

* **Vertical Velocity Update**
  - Update the `positionUpdateVelocityInternal` function in `position_estimator_altitude.c` to update the vertical velocity using barometer data.
  - Add a blending factor `baroAlpha` for barometer data in the `selfState_s` structure.

* **Parameter Addition**
  - Add a new parameter `baroAlpha` to the `posEstAlt` parameter group in `position_estimator_altitude.c`.

